### PR TITLE
feat: add matchzy_send_ready_chat_messages convar to silence .ready p…

### DIFF
--- a/src/ConfigConvars.cs
+++ b/src/ConfigConvars.cs
@@ -58,6 +58,13 @@ namespace MatchZy
         // Event/Webhook sending master switch (diagnostics)
         public FakeConVar<bool> eventsEnabled = new("matchzy_events_enabled", "Master switch for MatchZy event/webhook sending and retry queue processing. Default: true", true);
 
+        // Periodic warmup chat broadcasts prompting players to type .ready / showing the
+        // current ready count. Set to false when an external orchestrator (RCON
+        // css_forcestart, custom auto-ready plugin, etc.) owns the match-start flow —
+        // the .ready prompts become misleading noise in that case. Default: true to
+        // preserve existing behavior.
+        public FakeConVar<bool> sendReadyChatMessages = new("matchzy_send_ready_chat_messages", "Whether to periodically broadcast the 'Please type .ready' / 'current ready players' messages during warmup. Set to false when an external orchestrator owns match start. Default: true", true);
+
         // Center HTML notifications
         public FakeConVar<bool> centerHtmlNotifications = new("matchzy_center_html_notifications", "Whether to show important notifications in the center of the screen (match live, pause, etc). Default: false", false);
         public FakeConVar<int> notificationDurationGlobal = new("matchzy_notification_duration_global", "Default duration in seconds for global center HTML notifications. Default: 5", 5);

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -496,6 +496,11 @@ namespace MatchZy
         private void SendUnreadyPlayersMessage()
         {
             if (!isWarmup || matchStarted) return;
+            // Allow operators to silence the periodic "type .ready" prompts when an
+            // external orchestrator (RCON css_forcestart, custom auto-ready plugin,
+            // etc.) owns the match-start flow. The timer keeps ticking but no-ops,
+            // so the convar can be toggled at runtime.
+            if (!sendReadyChatMessages.Value) return;
             List<string> unreadyPlayers = new();
 
             foreach (var key in playerReadyStatus.Keys)


### PR DESCRIPTION
…rompts

When an external orchestrator owns the match-start flow (e.g. an admin plugin issuing css_forcestart over RCON, or a custom auto-ready system), the periodic "Please type .ready to ready up!" / "Current ready players" broadcasts from SendUnreadyPlayersMessage become misleading noise — the match is going to start without anyone typing .ready.

Add a new bool convar `matchzy_send_ready_chat_messages` (default: true, so upstream behavior is unchanged) that early-returns from SendUnreadyPlayersMessage when set to false. The repeat timer keeps ticking but no-ops, so the convar is runtime-toggleable.

Note this only suppresses the periodic chat spam — the per-player "You have been marked as ready" confirmations from .ready / .unready chat commands are intentionally left alone, since those are direct feedback to a player action rather than broadcast prompts.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🎯 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## ✅ Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have tested my changes locally
- [ ] I have updated the documentation (if applicable)

## 🧪 Testing

Describe how you tested your changes:

```bash
# Commands used to test
```

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 📎 Additional Notes

Any additional information or context.
