### PR TITLE
Fix practice teleport body rotation

### DIFF
--- a/src/ConsoleCommands.cs
+++ b/src/ConsoleCommands.cs
@@ -870,9 +870,7 @@ namespace MatchZy
             // inspired by cs2-noclip
             if (player.PlayerPawn.Value!.MoveType == MoveType_t.MOVETYPE_NOCLIP)
             {
-                player.PlayerPawn.Value.MoveType = MoveType_t.MOVETYPE_WALK;
-                player.PlayerPawn.Value.ActualMoveType = MoveType_t.MOVETYPE_WALK;
-                Utilities.SetStateChanged(player.PlayerPawn.Value, "CBaseEntity", "m_MoveType");
+                player.PlayerPawn.Value.ResetNoclipToWalk();
             }
             else
             {

--- a/src/GrenadeThrownData.cs
+++ b/src/GrenadeThrownData.cs
@@ -39,7 +39,8 @@ public class GrenadeThrownData
     public void LoadPosition(CCSPlayerController player)
     {
         if (player == null || player.PlayerPawn.Value == null) return;
-        player.PlayerPawn.Value.Teleport(PlayerPosition, PlayerAngle, new Vector(0, 0, 0));
+        player.PlayerPawn.Value.TeleportKeepingModelUpright(PlayerPosition, PlayerAngle, new Vector(0, 0, 0));
+        player.PlayerPawn.Value.ResetNoclipToWalk();
     }
 
     public void Throw(CCSPlayerController player)

--- a/src/PawnExtensions.cs
+++ b/src/PawnExtensions.cs
@@ -1,0 +1,37 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace MatchZy;
+
+public static class PawnExtensions
+{
+    public static void ResetNoclipToWalk(this CBasePlayerPawn? pawn)
+    {
+        if (pawn == null) return;
+        if (pawn.MoveType != MoveType_t.MOVETYPE_NOCLIP) return;
+
+        pawn.MoveType = MoveType_t.MOVETYPE_WALK;
+        pawn.ActualMoveType = MoveType_t.MOVETYPE_WALK;
+        Utilities.SetStateChanged(pawn, "CBaseEntity", "m_MoveType");
+    }
+
+    public static void TeleportKeepingModelUpright(this CBasePlayerPawn? pawn, Vector? position, QAngle? angle, Vector? velocity)
+    {
+        if (pawn == null) return;
+
+        pawn.Teleport(position, angle, velocity);
+        if (angle == null) return;
+
+        var sceneNode = pawn.CBodyComponent?.SceneNode;
+        if (sceneNode == null) return;
+
+        sceneNode.Rotation.X = 0f;
+        sceneNode.Rotation.Y = angle.Y;
+        sceneNode.Rotation.Z = 0f;
+        sceneNode.AbsRotation.X = 0f;
+        sceneNode.AbsRotation.Y = angle.Y;
+        sceneNode.AbsRotation.Z = 0f;
+        Utilities.SetStateChanged(pawn, "CBaseEntity", "m_CBodyComponent");
+    }
+}

--- a/src/PlayerLocationData.cs
+++ b/src/PlayerLocationData.cs
@@ -17,6 +17,6 @@ public class PlayerLocationData
     public void LoadPosition(CCSPlayerController player)
     {
         if (player == null || player.PlayerPawn.Value == null) return;
-        player.PlayerPawn.Value.Teleport(Position, Angle, new Vector(0, 0, 0));
+        player.PlayerPawn.Value.TeleportKeepingModelUpright(Position, Angle, new Vector(0, 0, 0));
     }
 }

--- a/src/PracticeMode.cs
+++ b/src/PracticeMode.cs
@@ -34,7 +34,7 @@ namespace MatchZy
 
         public void Teleport(CCSPlayerController player)
         {
-            player!.PlayerPawn.Value!.Teleport(PlayerPosition, PlayerAngle, new Vector(0, 0, 0));
+            player!.PlayerPawn.Value!.TeleportKeepingModelUpright(PlayerPosition, PlayerAngle, new Vector(0, 0, 0));
         }
 
         public override bool Equals(object? obj)
@@ -232,7 +232,8 @@ namespace MatchZy
                     // Adjusting the spawnNumber according to the array index.
                     spawnNumber -= 1;
                     if (spawnsData.ContainsKey(teamNum) && spawnsData[teamNum].Count <= spawnNumber) return;
-                    player!.PlayerPawn.Value!.Teleport(spawnsData[teamNum][spawnNumber].PlayerPosition, spawnsData[teamNum][spawnNumber].PlayerAngle, new Vector(0, 0, 0));
+                    player!.PlayerPawn.Value!.TeleportKeepingModelUpright(spawnsData[teamNum][spawnNumber].PlayerPosition, spawnsData[teamNum][spawnNumber].PlayerAngle, new Vector(0, 0, 0));
+                    player!.PlayerPawn.Value!.ResetNoclipToWalk();
                     // ReplyToUserCommand(player, $"Moved to spawn: {spawnNumber+1}/{spawnsData[teamNum].Count}");
                     ReplyToUserCommand(player, Localizer["matchzy.pm.movedtospawn", $"{spawnNumber + 1}/{spawnsData[teamNum].Count}"]);
                 }
@@ -645,7 +646,7 @@ namespace MatchZy
                                     QAngle loadedPlayerAngle = new QAngle(float.Parse(angArray[0]), float.Parse(angArray[1]), float.Parse(angArray[2]));
 
                                     // Teleport player
-                                    player!.PlayerPawn!.Value!.Teleport(loadedPlayerPos, loadedPlayerAngle, new Vector(0, 0, 0));
+                                    player!.PlayerPawn!.Value!.TeleportKeepingModelUpright(loadedPlayerPos, loadedPlayerAngle, new Vector(0, 0, 0));
 
                                     // Change player inv slot
                                     switch (lineupInfo["Type"])
@@ -996,7 +997,7 @@ namespace MatchZy
                             AddTimer(0.2f, () => tempPlayer.PlayerPawn.Value!.Bot!.IsCrouching = true);
                         }
 
-                        tempPlayer.PlayerPawn.Value!.Teleport(botOwnerPosition.PlayerPosition, botOwnerPosition.PlayerAngle, new Vector(0, 0, 0));
+                        tempPlayer.PlayerPawn.Value!.TeleportKeepingModelUpright(botOwnerPosition.PlayerPosition, botOwnerPosition.PlayerAngle, new Vector(0, 0, 0));
                         TemporarilyDisableCollisions(botOwner, tempPlayer);
                         unusedBotFound = true;
                     }
@@ -1068,7 +1069,7 @@ namespace MatchZy
         private static void ElevatePlayer(CCSPlayerController? player)
         {
             if (player == null || !player.IsValid || !player.PlayerPawn.IsValid || player.PlayerPawn.Value == null) return;
-            player.PlayerPawn.Value.Teleport(new Vector(player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.X, player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Y, player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Z + 80.0f), player.PlayerPawn.Value.EyeAngles, new Vector(0, 0, 0));
+            player.PlayerPawn.Value.TeleportKeepingModelUpright(new Vector(player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.X, player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Y, player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Z + 80.0f), player.PlayerPawn.Value.EyeAngles, new Vector(0, 0, 0));
         }
 
         [GameEventHandler]
@@ -1080,12 +1081,7 @@ namespace MatchZy
             // disable noclip on spawn -- all no clipping functionality is handled by the plugin!
             // Movement adjustments are consistent with cs2-noclip.
             CBasePlayerPawn pawn = player!.PlayerPawn.Value!;
-            if (pawn.MoveType == MoveType_t.MOVETYPE_NOCLIP)
-            {
-                pawn.MoveType = MoveType_t.MOVETYPE_WALK;
-                pawn.ActualMoveType = MoveType_t.MOVETYPE_WALK;
-                Utilities.SetStateChanged(pawn, "CBaseEntity", "m_MoveType");
-            }
+            pawn.ResetNoclipToWalk();
 
             if (matchStarted && (matchzyTeam1.coach.Contains(player!) || matchzyTeam2.coach.Contains(player!)))
             {
@@ -1105,7 +1101,7 @@ namespace MatchZy
                 {
                     if (pracUsedBots[player.UserId.Value]["position"] is Position botPosition)
                     {
-                        player.PlayerPawn.Value?.Teleport(botPosition.PlayerPosition, botPosition.PlayerAngle, new Vector(0, 0, 0));
+                        player.PlayerPawn.Value.TeleportKeepingModelUpright(botPosition.PlayerPosition, botPosition.PlayerAngle, new Vector(0, 0, 0));
                         bool isCrouched = (bool)pracUsedBots[player.UserId.Value]["crouchstate"];
                         if (isCrouched)
                         {
@@ -1817,7 +1813,8 @@ namespace MatchZy
                     closestIndex = index;
                 }
             }
-            player!.PlayerPawn.Value!.Teleport(teamSpawns[closestIndex].PlayerPosition, teamSpawns[closestIndex].PlayerAngle, new Vector(0, 0, 0));
+            player!.PlayerPawn.Value!.TeleportKeepingModelUpright(teamSpawns[closestIndex].PlayerPosition, teamSpawns[closestIndex].PlayerAngle, new Vector(0, 0, 0));
+            player!.PlayerPawn.Value!.ResetNoclipToWalk();
         }
 
         public void TeleportPlayerToWorstSpawn(CCSPlayerController player, byte teamNum)
@@ -1837,7 +1834,8 @@ namespace MatchZy
                     farthestIndex = index;
                 }
             }
-            player!.PlayerPawn.Value!.Teleport(teamSpawns[farthestIndex].PlayerPosition, teamSpawns[farthestIndex].PlayerAngle, new Vector(0, 0, 0));
+            player!.PlayerPawn.Value!.TeleportKeepingModelUpright(teamSpawns[farthestIndex].PlayerPosition, teamSpawns[farthestIndex].PlayerAngle, new Vector(0, 0, 0));
+            player!.PlayerPawn.Value!.ResetNoclipToWalk();
         }
 
         // Todo: Implement timer2 when we have OnPlayerRunCmd in CS#. Using OnTick would be its alternative, but it would be very expensive and not worth it.


### PR DESCRIPTION
## Summary

Ports the practice teleport fix from the DatHost MatchZy comparison for issue #10.

Adds a pawn teleport helper that keeps the player view angle intact while flattening the rendered body rotation back to yaw-only, so commands like .loadnade, .last / .back, .boost / .crouchboost, and .loadpos no longer rotate or tilt the entire player model.

Also centralizes the noclip-to-walk reset used after practice teleports.

## Credits

Based on the upstream fix from nuxen / the DatHost MatchZy branch:
https://github.com/shobhit-pathak/MatchZy/compare/dev...dathost:MatchZy:dev

Thanks to @Pulviinus for reporting this in MatchZy Enhanced.

## Testing

- Ran git diff --check
- Could not run dotnet build locally because dotnet is not installed in this shell

Fixes #10