### PR TITLE
fix(ready): stop a failed player scan from wiping the player map

### DIFF
--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -1471,51 +1471,80 @@ namespace MatchZy
             {
                 var playerEntities = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller");
                 Log($"[UpdatePlayersMap] CCSPlayerController count: {playerEntities.Count<CCSPlayerController>()} matchModeOnly: {matchModeOnly}");
-                connectedPlayers = 0;
 
-                // Clear the playerData dictionary by creating a new instance to add fresh data.
-                playerData = new Dictionary<int, CCSPlayerController>();
+                // Build into a local map and swap it in only once the whole scan
+                // has succeeded.
+                //
+                // This used to clear playerData up front and fill it in place.
+                // Every member access in the loop below can throw on an entity
+                // that is mid-disconnect or otherwise not fully valid, and the
+                // catch at the bottom swallows it — so one bad entity left
+                // playerData empty or half-built, and the plugin then believed
+                // nobody was on the server. IsTeamReady logs playerCount:0 for
+                // every team, .ready stops registering, and the match never goes
+                // live, with nothing but a single FATAL line to say why.
+                //
+                // Failing now leaves the previous good map in place instead.
+                var updatedPlayerData = new Dictionary<int, CCSPlayerController>();
+                int updatedConnectedPlayers = 0;
+
                 foreach (var player in playerEntities)
                 {
-                    if (player == null) continue;
-                    if (!player.IsValid || player.IsHLTV) continue;
-
-                    bool isSimulationBot = isSimulationMode && player.IsBot;
-
-                    // Outside of simulation mode, we still ignore bots in playerData – they are not
-                    // considered "real players" for the ready system or whitelist enforcement.
-                    if (!isSimulationBot && player.IsBot) continue;
-
-                    // In normal (non-simulation) matches, enforce that only configured players are
-                    // allowed to remain on the server when a match is setup / matchModeOnly is true.
-                    // Simulation bots are exempt from this so we do not immediately kick them.
-                    if ((isMatchSetup || matchModeOnly) && !isSimulationBot)
+                    try
                     {
-                        CsTeam team = GetPlayerTeam(player);
-                        if (team == CsTeam.None && player.UserId.HasValue)
+                        if (player == null) continue;
+                        if (!player.IsValid || player.IsHLTV) continue;
+
+                        bool isSimulationBot = isSimulationMode && player.IsBot;
+
+                        // Outside of simulation mode, we still ignore bots in playerData – they are not
+                        // considered "real players" for the ready system or whitelist enforcement.
+                        if (!isSimulationBot && player.IsBot) continue;
+
+                        // In normal (non-simulation) matches, enforce that only configured players are
+                        // allowed to remain on the server when a match is setup / matchModeOnly is true.
+                        // Simulation bots are exempt from this so we do not immediately kick them.
+                        if ((isMatchSetup || matchModeOnly) && !isSimulationBot)
                         {
-                            Log($"[UpdatePlayersMap] Executing kickid for player '{player.PlayerName}' (UserId={(ushort)player.UserId.Value}) because team=None in match-only mode (isSimulationMode={isSimulationMode}, IsBot={player.IsBot}).");
-                            Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
-                            continue;
+                            CsTeam team = GetPlayerTeam(player);
+                            if (team == CsTeam.None && player.UserId.HasValue)
+                            {
+                                Log($"[UpdatePlayersMap] Executing kickid for player '{player.PlayerName}' (UserId={(ushort)player.UserId.Value}) because team=None in match-only mode (isSimulationMode={isSimulationMode}, IsBot={player.IsBot}).");
+                                Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
+                                continue;
+                            }
                         }
+
+                        // A player controller still exists after a player disconnects
+                        // Hence checking whether the player is actually in the server or not
+                        if (player.Connected != PlayerConnectedState.PlayerConnected) continue;
+
+                        if (player.UserId.HasValue)
+                        {
+                            updatedPlayerData[player.UserId.Value] = player;
+                        }
+                        updatedConnectedPlayers++;
                     }
-
-                    // A player controller still exists after a player disconnects
-                    // Hence checking whether the player is actually in the server or not
-                    if (player.Connected != PlayerConnectedState.PlayerConnected) continue;
-
-                    if (player.UserId.HasValue)
+                    catch (Exception playerError)
                     {
-                        // Updating playerData and playerReadyStatus
-                        playerData[player.UserId.Value] = player;
-
-                        // Adding missing player in playerReadyStatus
-                        if (!playerReadyStatus.ContainsKey(player.UserId.Value))
-                        {
-                            playerReadyStatus[player.UserId.Value] = false;
-                        }
+                        // One unreadable entity must not cost us the whole
+                        // refresh. Skip it and keep going.
+                        Log($"[UpdatePlayersMap] Skipping a player entity that could not be read: {playerError.Message}");
                     }
-                    connectedPlayers++;
+                }
+
+                // The scan completed, so this map is trustworthy. Publish it.
+                playerData = updatedPlayerData;
+                connectedPlayers = updatedConnectedPlayers;
+
+                // Adding missing players in playerReadyStatus. Done after the
+                // swap so a failed scan can never drop a player's ready state.
+                foreach (var key in playerData.Keys)
+                {
+                    if (!playerReadyStatus.ContainsKey(key))
+                    {
+                        playerReadyStatus[key] = false;
+                    }
                 }
 
                 // Removing disconnected players from playerReadyStatus
@@ -1531,7 +1560,10 @@ namespace MatchZy
             }
             catch (Exception e)
             {
-                Log($"[UpdatePlayersMap FATAL] An error occurred: {e.Message}");
+                // playerData and connectedPlayers are left untouched: the local
+                // map is only published on success, so a failure here means
+                // "could not refresh", not "there is nobody on the server".
+                Log($"[UpdatePlayersMap FATAL] An error occurred, keeping the previous player map ({playerData.Count} players): {e.Message}");
             }
         }
 


### PR DESCRIPTION
Candidate fix for the `.ready` reports (MAT-side tracking: Vikunja #7).

## The symptom

Reported three separate times and never resolved: everyone types `.ready` and
nothing happens. The server log shows

```
[IsTeamReady] team: 3 minPlayers:3 minReady:1 playerCount:0 readyCount:0
[IsTeamReady] team: 1 minPlayers:0 minReady:0 playerCount:0
```

`playerCount: 0` on **every** team, while players are connected and readying up.

## Where that comes from

`GetTeamPlayerCount` counts `playerData`. `UpdatePlayersMap` cleared it before
refilling:

```csharp
connectedPlayers = 0;
playerData = new Dictionary<int, CCSPlayerController>();
foreach (var player in playerEntities) { ... }
```

Every member access in that loop — `IsValid`, `IsHLTV`, `IsBot`,
`GetPlayerTeam`, `Connected` — can throw on an entity that is mid-connect,
mid-disconnect, or otherwise not fully valid. The `catch` at the bottom
swallows it.

So **one bad entity leaves `playerData` empty or half-built**, and the plugin
then believes nobody is on the server. Nothing recovers on its own: the map is
only rebuilt when `UpdatePlayersMap` runs again. Until then `.ready` cannot
register, `IsTeamsReady()` never returns true, and the match never goes live —
with a single `[UpdatePlayersMap FATAL]` line as the only clue.

That matches the reported log exactly, including *all* teams reading zero
rather than just one.

## The fix

**Publish atomically.** Build into a local map and assign it only once the scan
completes. A failure now means "could not refresh" — the previous good map
stays — rather than "there is nobody here".

**Guard each entity.** One unreadable player is skipped and logged instead of
costing the whole refresh.

`playerReadyStatus` top-up also moved after the swap, so a failed scan can no
longer drop a player's ready state.

## Status

Builds clean (0 warnings, 0 errors). It fixes a real destructive-update defect
regardless, but **it has not been confirmed against a reporter's server** — I
have no repro of the underlying throw. The `[UpdatePlayersMap] Skipping a
player entity...` line this adds will show whether a skip is what they are
hitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)