### PR TITLE
ci: build the plugin on every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+# The plugin had no build check at all: a pull request could be merged without
+# anything having compiled it. Release.yml only runs on demand, after the fact.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore
+
+      # Warnings are not errors here yet — the existing code would not pass that
+      # today, and turning it on in the same change that introduces the check
+      # would mean landing a red build. Worth revisiting once the tree is clean.
+      - name: Build
+        run: dotnet build -c Release --no-restore --nologo


### PR DESCRIPTION
## The gap

There is no build check on this repo. `release.yml` compiles the plugin, but
only on `workflow_dispatch` — so a pull request can be reviewed and merged
**without anything having compiled it**, and a break surfaces at release time.

This came up concretely: #14 was merged on the strength of a local
`dotnet build` and nothing else.

## This

Builds on every pull request, and on pushes to `main` and `dev`, using the same
.NET 8 setup `release.yml` already uses.

Warnings are left non-fatal for now — turning that on in the same change that
introduces the check would mean landing a red build. Worth revisiting once the
tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)